### PR TITLE
fix dns resolution issue by stripping port from host before passing it to pacparser

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"strings"
 )
 
 // TestURL used by IsValid()
@@ -61,7 +60,7 @@ func (inst *ParserInstance) FindProxy(urlString string) (bool, string) {
 	req := new(findProxyRequest)
 	req.inst = inst
 	req.url = u.String()
-	req.host = strings.Split(u.Host, ":")[0]
+	req.host = u.Hostname()
 	req.resp = make(chan *parserResponse, 1)
 	// send request
 	findProxyChannel <- req

--- a/helpers.go
+++ b/helpers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"strings"
 )
 
 // TestURL used by IsValid()
@@ -60,7 +61,7 @@ func (inst *ParserInstance) FindProxy(urlString string) (bool, string) {
 	req := new(findProxyRequest)
 	req.inst = inst
 	req.url = u.String()
-	req.host = u.Host
+	req.host = strings.Split(u.Host, ":")[0]
 	req.resp = make(chan *parserResponse, 1)
 	// send request
 	findProxyChannel <- req

--- a/pacparser_test.go
+++ b/pacparser_test.go
@@ -3,11 +3,12 @@ package pacparser
 // go-pacparser - golang bindings for pacparser library
 
 import (
-	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 // everything we need to run our tests
@@ -194,6 +195,16 @@ func (s *pacparserTestSuite) TestGood() {
 	s.True(ok)
 	s.Equal("DIRECT", pxy)
 	s.Nil(pp.LastError())
+
+	// exectute FindProxyForURL and log
+	ok, pxy = pp.FindProxy("https://192.168.1.1.xip.io:4433/path")
+	s.T().Logf("[good1.pac] url: https://192.168.1.1.xip.io:4433/path pxy: %s", pxy)
+
+	// assert returns
+	s.True(ok)
+	s.Equal("DIRECT", pxy)
+	s.Nil(pp.LastError())
+
 }
 
 // test with IsValid


### PR DESCRIPTION
When the input `urlString` contains host in explicit `host:port` format, this binding sends both `host:port` without stripping the `port` beforehand. This causes issues on DNS resolution on `dnsResolve()` call inside the pacfile because the library attempts to resolve the whole `host:port` string instead of just `host`.

I've attached packet capture that demonstrates the issue. The actual DNS query is `A? null.` whereas expected query would be `A? 192.168.1.1.xip.io.` However, I haven't fully tracked down why it is asking for `A? null` instead of `A? 192.168.1.1.xip.io:4433`.

## Run with added test case with url that has explicit port definition

```
$ git status
HEAD detached at de7a265
nothing to commit, working tree clean
```
### Test run
```
$ go test -run TestSuite/TestGood -v -count=1
=== RUN   TestSuite
=== RUN   TestSuite/TestGood
    pacparser_test.go:150: [good1.pac] url: http://www.google.com/ ip: 10.10.5.6 pxy: PROXY 1.2.3.4:8080
    pacparser_test.go:165: [good1.pac] url: http://www.google.com/ ip: 127.0.0.1 pxy: PROXY 4.5.6.7:8080; PROXY 7.8.9.10:8080
    pacparser_test.go:174: [good1.pac] url: http://test.local/ pxy: DIRECT
    pacparser_test.go:183: [good1.pac] url: http://localhost/ pxy: DIRECT
    pacparser_test.go:192: [good1.pac] url: http://www.abcdomain.com/ pxy: DIRECT
    pacparser_test.go:201: [good1.pac] url: https://192.168.1.1.xip.io:4433/path pxy: PROXY 4.5.6.7:8080; PROXY 7.8.9.10:8080
    pacparser_test.go:205:
                Error Trace:    pacparser_test.go:205
                Error:          Not equal:
                                expected: "DIRECT"
                                actual  : "PROXY 4.5.6.7:8080; PROXY 7.8.9.10:8080"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -DIRECT
                                +PROXY 4.5.6.7:8080; PROXY 7.8.9.10:8080
                Test:           TestSuite/TestGood
--- FAIL: TestSuite (0.71s)
    --- FAIL: TestSuite/TestGood (0.70s)
FAIL
exit status 1
FAIL    _/opt/appsulate/go-pacparser    0.710s

```

### Packet capture
```
14:53:01.334560 IP 10.171.195.86.42399 > 8.8.8.8.53: 40803+ A? www.google.com. (32)
14:53:01.385335 IP 8.8.8.8.53 > 10.171.195.86.42399: 40803 1/0/0 A 216.58.203.4 (48)
14:53:01.386018 IP 10.171.195.86.60570 > 8.8.8.8.53: 56611+ A? www.google.com. (32)
14:53:01.441339 IP 8.8.8.8.53 > 10.171.195.86.60570: 56611 1/0/0 A 216.58.203.4 (48)
14:53:01.441940 IP 10.171.195.86.39740 > 8.8.8.8.53: 60374+ A? www.google.com. (32)
14:53:01.506277 IP 8.8.8.8.53 > 10.171.195.86.39740: 60374 1/0/0 A 216.58.203.132 (48)
14:53:01.506867 IP 10.171.195.86.46770 > 8.8.8.8.53: 52861+ A? www.google.com. (32)
14:53:01.579701 IP 8.8.8.8.53 > 10.171.195.86.46770: 52861 1/0/0 A 216.58.203.132 (48)
14:53:01.589128 IP 10.171.195.86.45973 > 8.8.8.8.53: 48236+ A? www.google.com. (32)
14:53:01.647767 IP 8.8.8.8.53 > 10.171.195.86.45973: 48236 1/0/0 A 216.58.203.132 (48)
14:53:01.648309 IP 10.171.195.86.37192 > 8.8.8.8.53: 60109+ A? www.google.com. (32)
14:53:01.707202 IP 8.8.8.8.53 > 10.171.195.86.37192: 60109 1/0/0 A 216.58.203.132 (48)
14:53:01.707777 IP 10.171.195.86.48018 > 8.8.8.8.53: 48065+ A? www.google.com. (32)
14:53:01.762383 IP 8.8.8.8.53 > 10.171.195.86.48018: 48065 1/0/0 A 216.58.203.4 (48)
14:53:01.763014 IP 10.171.195.86.43439 > 8.8.8.8.53: 46784+ A? www.google.com. (32)
14:53:01.854039 IP 8.8.8.8.53 > 10.171.195.86.43439: 46784 1/0/0 A 216.58.203.4 (48)
14:53:01.886219 IP 10.171.195.86.33944 > 8.8.8.8.53: 7440+ A? null. (22)
14:53:01.938341 IP 8.8.8.8.53 > 10.171.195.86.33944: 7440 NXDomain 0/1/0 (97)
14:53:01.938812 IP 10.171.195.86.38814 > 8.8.8.8.53: 14794+ A? null. (22)
14:53:01.990229 IP 8.8.8.8.53 > 10.171.195.86.38814: 14794 NXDomain 0/1/0 (97)
14:53:01.990715 IP 10.171.195.86.39912 > 8.8.8.8.53: 32785+ A? null. (22)
14:53:02.044222 IP 8.8.8.8.53 > 10.171.195.86.39912: 32785 NXDomain 0/1/0 (97)
14:53:02.044585 IP 10.171.195.86.33601 > 8.8.8.8.53: 34339+ A? null. (22)
14:53:02.096090 IP 8.8.8.8.53 > 10.171.195.86.33601: 34339 NXDomain 0/1/0 (97)
```

## Run with added test case and fix applied

```
$ git status
HEAD detached at 704eb70
nothing to commit, working tree clean
```

### Test run
```
$ go test -run TestSuite/TestGood -v -count=1
=== RUN   TestSuite
=== RUN   TestSuite/TestGood
    pacparser_test.go:150: [good1.pac] url: http://www.google.com/ ip: 10.10.5.6 pxy: PROXY 1.2.3.4:8080
    pacparser_test.go:165: [good1.pac] url: http://www.google.com/ ip: 127.0.0.1 pxy: PROXY 4.5.6.7:8080; PROXY 7.8.9.10:8080
    pacparser_test.go:174: [good1.pac] url: http://test.local/ pxy: DIRECT
    pacparser_test.go:183: [good1.pac] url: http://localhost/ pxy: DIRECT
    pacparser_test.go:192: [good1.pac] url: http://www.abcdomain.com/ pxy: DIRECT
    pacparser_test.go:201: [good1.pac] url: https://192.168.1.1.xip.io:4433/path pxy: DIRECT
--- PASS: TestSuite (1.78s)
    --- PASS: TestSuite/TestGood (1.78s)
PASS
ok      _/opt/appsulate/go-pacparser    1.782s

```

### Packet capture
```
15:00:53.749376 IP 10.171.195.86.59857 > 8.8.8.8.53: 28069+ A? www.google.com. (32)
15:00:53.823935 IP 8.8.8.8.53 > 10.171.195.86.59857: 28069 1/0/0 A 216.58.203.132 (48)
15:00:53.824513 IP 10.171.195.86.33956 > 8.8.8.8.53: 13839+ A? www.google.com. (32)
15:00:53.887662 IP 8.8.8.8.53 > 10.171.195.86.33956: 13839 1/0/0 A 216.58.203.4 (48)
15:00:53.888176 IP 10.171.195.86.48561 > 8.8.8.8.53: 46712+ A? www.google.com. (32)
15:00:53.942751 IP 8.8.8.8.53 > 10.171.195.86.48561: 46712 1/0/0 A 216.58.203.132 (48)
15:00:53.943315 IP 10.171.195.86.41565 > 8.8.8.8.53: 48618+ A? www.google.com. (32)
15:00:53.991397 IP 8.8.8.8.53 > 10.171.195.86.41565: 48618 1/0/0 A 216.58.203.4 (48)
15:00:54.001122 IP 10.171.195.86.59966 > 8.8.8.8.53: 64+ A? www.google.com. (32)
15:00:54.069802 IP 8.8.8.8.53 > 10.171.195.86.59966: 64 1/0/0 A 216.58.203.132 (48)
15:00:54.070017 IP 10.171.195.86.32794 > 8.8.8.8.53: 54216+ A? www.google.com. (32)
15:00:54.118934 IP 8.8.8.8.53 > 10.171.195.86.32794: 54216 1/0/0 A 216.58.203.4 (48)
15:00:54.119461 IP 10.171.195.86.51710 > 8.8.8.8.53: 61676+ A? www.google.com. (32)
15:00:54.171792 IP 8.8.8.8.53 > 10.171.195.86.51710: 61676 1/0/0 A 216.58.203.132 (48)
15:00:54.172336 IP 10.171.195.86.54959 > 8.8.8.8.53: 15591+ A? www.google.com. (32)
15:00:54.223729 IP 8.8.8.8.53 > 10.171.195.86.54959: 15591 1/0/0 A 216.58.203.4 (48)
15:00:54.254729 IP 10.171.195.86.35117 > 8.8.8.8.53: 1342+ A? 192.168.1.1.xip.io. (36)
15:00:54.732816 IP 8.8.8.8.53 > 10.171.195.86.35117: 1342 1/0/0 A 192.168.1.1 (52)
15:00:54.733418 IP 10.171.195.86.48923 > 8.8.8.8.53: 31371+ A? 192.168.1.1.xip.io. (36)
15:00:54.785571 IP 8.8.8.8.53 > 10.171.195.86.48923: 31371 1/0/0 A 192.168.1.1 (52)
15:00:54.786210 IP 10.171.195.86.52849 > 8.8.8.8.53: 56912+ A? 192.168.1.1.xip.io. (36)
15:00:54.838348 IP 8.8.8.8.53 > 10.171.195.86.52849: 56912 1/0/0 A 192.168.1.1 (52)
```